### PR TITLE
Enable to use HTML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ This resource can post **one story**, so you should prepare preprocessing task(e
 ### `out`: Post an article.
 Posts an article to medium based on parameters.
 #### Parameters
-* `content_file`: Required. This Resource posts an article based on specified file.
-* `format`: Optional. Default `markdown`. if you want to use `html`, please set it.
-* `title`: Optional. If this parameter does not set, first-line of the `content_file` is used as title.
+* `content_file`: Required. This Resource posts an article based on specified file(Markdown or HTML).
 * `tags`: Optional. You can set tags as array.
 * `canonical_url`: Optional.
 * `status`: Optional. Default `draft`.

--- a/in/models.go
+++ b/in/models.go
@@ -4,15 +4,18 @@ import (
 	"github.com/cappyzawa/medium-resource"
 )
 
+// Request is payload input to in.
 type Request struct {
 	Source  resource.Source
 	Params  Params
 	Version resource.Version
 }
 
+// Params is parameters for get.
 type Params struct {
 }
 
+// Response outputs version and metadata for resource.
 type Response struct {
 	Version  resource.Version
 	Metadata []resource.MetadataPair

--- a/out/command.go
+++ b/out/command.go
@@ -96,7 +96,7 @@ func (c *Command) ExtractFromFile(filePath string) (medium.ContentFormat, string
 		}
 		return medium.ContentFormat(medium.ContentFormatMarkdown), title, content, nil
 	case ".html":
-		title, content, err := c.extractTitleAndContentByHtml(contents)
+		title, content, err := c.extractTitleAndContentByHTML(contents)
 		if err != nil {
 			return "", "", "", err
 		}
@@ -113,7 +113,7 @@ func (c *Command) extractTitleAndContentByMd(contents []byte) (string, string, e
 	return title, content, nil
 }
 
-func (c *Command) extractTitleAndContentByHtml(contents []byte) (string, string, error) {
+func (c *Command) extractTitleAndContentByHTML(contents []byte) (string, string, error) {
 	matched := r.FindSubmatch(contents)
 	// matched = <title>title</title>
 	title := strings.TrimSuffix(strings.TrimPrefix(string(matched[0]), "<title>"), "</title>")

--- a/out/command.go
+++ b/out/command.go
@@ -4,11 +4,19 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"path"
+	"regexp"
 	"strings"
 
 	"github.com/Medium/medium-sdk-go"
 	"github.com/cappyzawa/medium-resource"
 )
+
+var r *regexp.Regexp
+
+func init() {
+	r = regexp.MustCompile(`<title>.*?</title>`)
+}
 
 // Command has MediumClient for posting a content.
 type Command struct {
@@ -33,24 +41,19 @@ func (c *Command) Run(sourceDir string, request Request) (*Response, error) {
 		UserID:        u.ID,
 		Title:         "",
 		Content:       "",
-		ContentFormat: medium.ContentFormatMarkdown,
+		ContentFormat: "",
 		Tags:          []string{},
 		CanonicalURL:  "",
 		PublishStatus: medium.PublishStatusDraft,
 		License:       "",
 	}
-	title, content, err := c.ExtractTitleAndContent(fmt.Sprintf("%s/%s", sourceDir, request.Params.ContentFile))
+	format, title, content, err := c.ExtractFromFile(fmt.Sprintf("%s/%s", sourceDir, request.Params.ContentFile))
 	if err != nil {
 		return nil, err
 	}
 	o.Content = content
 	o.Title = title
-	if request.Params.Title != "" {
-		o.Title = request.Params.Title
-	}
-	if request.Params.Format != "" {
-		o.ContentFormat = medium.ContentFormat(request.Params.Format)
-	}
+	o.ContentFormat = format
 	if len(request.Params.Tags) != 0 {
 		o.Tags = append(o.Tags, request.Params.Tags...)
 	}
@@ -79,14 +82,43 @@ func (c *Command) Run(sourceDir string, request Request) (*Response, error) {
 	}, nil
 }
 
-// ExtractTitleAndContent extracts title and content from file.
-func (c *Command) ExtractTitleAndContent(path string) (string, string, error) {
-	contents, err := ioutil.ReadFile(path)
+// ExtractFromFile extracts format, title, content from file.
+func (c *Command) ExtractFromFile(filePath string) (medium.ContentFormat, string, string, error) {
+	contents, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
+	switch path.Ext(filePath) {
+	case ".md":
+		title, content, err := c.extractTitleAndContentByMd(contents)
+		if err != nil {
+			return "", "", "", err
+		}
+		return medium.ContentFormat(medium.ContentFormatMarkdown), title, content, nil
+	case ".html":
+		title, content, err := c.extractTitleAndContentByHtml(contents)
+		if err != nil {
+			return "", "", "", err
+		}
+		return medium.ContentFormatHTML, title, content, nil
+	default:
+		return "", "", "", errors.New("no support ext: " + path.Ext(filePath))
+	}
+}
+
+func (c *Command) extractTitleAndContentByMd(contents []byte) (string, string, error) {
 	separated := strings.Split(string(contents), "\n")
 	title := strings.TrimLeft(separated[0], "# ")
 	content := strings.Join(separated[1:], "\n")
-	return title, content, err
+	return title, content, nil
+}
+
+func (c *Command) extractTitleAndContentByHtml(contents []byte) (string, string, error) {
+	matched := r.FindSubmatch(contents)
+	// matched = <title>title</title>
+	title := strings.TrimSuffix(strings.TrimPrefix(string(matched[0]), "<title>"), "</title>")
+	if title == "" {
+		return "", "", errors.New("title tag is required")
+	}
+	return title, string(contents), nil
 }

--- a/out/models.go
+++ b/out/models.go
@@ -10,8 +10,6 @@ type Request struct {
 
 // Params is parameters for put.
 type Params struct {
-	Title        string   `json:"title"`
-	Format       string   `json:"format"`
 	ContentFile  string   `json:"content_file"`
 	Tags         []string `json:"tags"`
 	CanonicalURL string   `json:"canonical_url"`

--- a/testdata/out/content_file.go
+++ b/testdata/out/content_file.go
@@ -1,0 +1,10 @@
+package testout
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprint(os.Stdout, "test")
+}

--- a/testdata/out/content_file.html
+++ b/testdata/out/content_file.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>title</title>
+</head>
+<body>
+body
+</body>
+</html>


### PR DESCRIPTION
* if HTML file is set as `content_file`, <title> tas uses as title!
* `title` and `format` paramters are fired because those is judged by content_file.